### PR TITLE
fix circular dependency bug for AMD

### DIFF
--- a/src/inject.coffee
+++ b/src/inject.coffee
@@ -1244,13 +1244,19 @@ define = (moduleId, deps, callback) ->
     db.queue.amd.clear(moduleId)
     
   outstandingAMDModules = 0
+  noCircularDeps = []
   for depId in allDeps
     if db.module.getAmd(depId) and db.module.getLoading(depId)
       outstandingAMDModules++
       db.queue.amd.add depId, () -> 
         if --outstandingAMDModules is 0
           afterLoadModules()
-  loadModules allDeps, afterLoadModules
+    if db.module.getCircular(depId) is false
+      noCircularDeps.push depId
+  if db.module.getCircular(moduleId)
+    loadModules noCircularDeps, afterLoadModules
+  else
+    loadModules allDeps, afterLoadModules
 
 # To allow a clear indicator that a global define function conforms to the AMD API
 define['amd'] =

--- a/tests/amd/amd.js
+++ b/tests/amd/amd.js
@@ -31,8 +31,8 @@ asyncTest("Function String", 8, function() {
     var one = require('one'),
     two = require('two'),
     three = require('three'),
-    args = one.doSomething(),
-    oneMod = one.module;
+    args = two.doSomething(),
+    oneMod = two.getOneModule();
     
     equal("large", one.size);
     equal("small", two.size);

--- a/tests/amd/includes/spec/funcstring/two.js
+++ b/tests/amd/includes/spec/funcstring/two.js
@@ -1,14 +1,14 @@
 define(function(require) {
     //Dependencies
-    //var one = require('one');
+    var one = require('one');
     return {
         size: "small",
         color: "redtwo",
         doSomething: function() {
-            //return one.doSomething();
+            return one.doSomething();
         },
         getOneModule: function() {
-            //return one.module;
+            return one.module;
         }
     };
 });


### PR DESCRIPTION
add circular dependency stuff back to AMD funcstring test and follow the AMD test spec
