### PR TITLE
File names fix for Firebug's Scripts tab

### DIFF
--- a/src/inject.coffee
+++ b/src/inject.coffee
@@ -925,8 +925,8 @@ executeFile = (moduleId) ->
                          .replace(/__POINTCUT_AFTER__/g, cuts.after)
   sourceString = if isIE then "" else "//@ sourceURL=#{path}"
   
-  runHeader = [sourceString, header].join("\n")
-  runCmd = [runHeader, text, ";", footer].join("\n")
+  runHeader = header + "\n"
+  runCmd = [runHeader, text, ";", footer, sourceString].join("\n")
 
   # todo: circular dependency resolution
   try


### PR DESCRIPTION
Moving where sourceString gets appended to the eval'd code, which seems to fix the Firebug trick.
