### PR TITLE
Fix for require.manifest taking string values

### DIFF
--- a/src/inject.coffee
+++ b/src/inject.coffee
@@ -1166,7 +1166,7 @@ require.manifest = (manifest) ->
   ###
   for own item, rules of manifest
     ruleSet =
-      path: rules.path or null
+      path: rules.path or rules or null
       pointcuts:
         before: rules.before or null
         after: rules.after or null


### PR DESCRIPTION
Fix manifest code to correctly take in a string in the value position of the pair.

Passing in a string as the value of a manifest key/value pair resulted
in an error because it was trying to reference the `path` property on the
string rather than taking the string itself as the value.
