### PR TITLE
Fix bug where an '=' or ',' character right before the require statement breaks loading of module

### DIFF
--- a/src/inject.coffee
+++ b/src/inject.coffee
@@ -818,7 +818,7 @@ extractRequires = (file) ->
   # collect runtime requirements
   reqs = []
   file = file.replace(commentRegex, "")
-  reqs.push(match[0]) while (match = requireRegex.exec(file))
+  reqs.push(match[0].match(/require.*/)[0]) while (match = requireRegex.exec(file))
   if reqs?.length > 0
     try
       eval(reqs.join(";"))

--- a/tests/modules-1.0/includes/bugs/bug_require.js
+++ b/tests/modules-1.0/includes/bugs/bug_require.js
@@ -1,0 +1,4 @@
+var b=require('bug_require_a');
+
+exports.foo = "bar";
+ok(true, "bug require loaded");

--- a/tests/modules-1.0/includes/bugs/bug_require_a.js
+++ b/tests/modules-1.0/includes/bugs/bug_require_a.js
@@ -1,0 +1,3 @@
+exports.foo = "bar";
+ok(true, "require statement with no space before require should have run");
+start();

--- a/tests/modules-1.0/modules-1.0.js
+++ b/tests/modules-1.0/modules-1.0.js
@@ -63,3 +63,9 @@ asyncTest("#65 circular dependencies should be resolved", 4, function() {
   require.setModuleRoot("http://localhost:4000/tests/modules-1.0/includes/bugs");
   require.run("bug_65");
 });
+
+// requiring a module that has commented lines- those lines should not run
+asyncTest("require() statements with no space before them should still run", 2, function() {
+  require.setModuleRoot("http://localhost:4000/tests/modules-1.0/includes/bugs");
+  require.run("bug_require");
+});


### PR DESCRIPTION
Fix bug where an '=' or ',' character right before the require statement broke the loading of the module.  I run into this situation a lot when I use uglify to minify my js code.

There's probably a better way to solve this by tweaking the main regex that extracts the require statements from the script but this works and provides some tests to demonstrate the problem.
