### PR TITLE
Notes for minified sources

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -26,6 +26,8 @@ You can visit http://localhost:4000/examples/ for viewing some sample code, or h
 
 Getting Started
 ===
+In case you're looking: [Building Inject From Source](https://github.com/linkedin/inject/wiki/Building-Inject-From-Source)
+
 We've put together a [Getting Started With inject Guide](https://github.com/linkedin/inject/wiki) which is a launching point to all to functionality inject has to offer. If you're already familiar with CommonJS-style modules, than you can probably start right there.
 
 Writing CommonJS Compliant Modules
@@ -44,6 +46,16 @@ exports.duck = waterfowl
 ```
 
 If you injected this file, you could then say `var duck = new moduleName.duck()` and instantiate your object.
+
+JavaScript Minifiers
+===
+If you're using a JS Minifier for your module files (and you probably should), there are some important compilation options you need. Many minifiers obfuscate and optimize variables inside of functions, which will affect the ability of inject to identify your dependencies before runtime. For the greatest in-browser optimization, we recommend using [UglifyJS](https://github.com/mishoo/UglifyJS) since it allows you to protect specific reserved names while still mazimixing the amount of compression you can do. If running node isn't an option, YUI and Google compressors can also be used with the following options:
+
+* UglifyJS: `--reserved-names “require,exports,module"`
+* YUI Compressor: `--nomunge`
+* Google Closure: `--compilation_level WHITESPACE_ONLY`
+
+If your compression engine of choice isn't on the list, and has the ability to protect/preserve certain names, send us a bug with the settings and we'll add it to the list. As a last ditch effort, you can often put an `eval();` after your return statement. For most optimizers, the addition of an eval will prevent variable munging within the current scope chain.
 
 API Notes
 ===


### PR DESCRIPTION
This addresses #92 and #93. We added information about minifiers to the README file, and then also added a wiki page regarding building from source. Looking at how different minifiers work, the `--reserved-names` option for UglifyJS is by far the best since you can protect `require`, `module`, and `exports` which is perfect for module needs.
