### PR TITLE
Fix for issue #95 - localStorage errors

### DIFF
--- a/src/inject.coffee
+++ b/src/inject.coffee
@@ -577,16 +577,19 @@ clearFileRegistry = (version = schemaVersion) ->
   _internal_ Clears the internal file registry at `version`
   clearing all local storage keys that relate to the fileStorageToken and version
   ###
+  
+  if ! ('localStorage' in context) then return
+    
   token = "#{fileStorageToken}#{version}"
-  keys = []
   `
   for (var i = 0; i < localStorage.length; i++) {
     var key = localStorage.key(i);
-    if (key.indexOf(token) !== -1) keys.push(key)
+    if (key.indexOf(token) !== -1) {
+      localStorage.removeItem(key)
+    }
   }
   `
-  for key in keys
-    localStorage.removeItem(key)
+  
   if version is schemaVersion then db.module.clearAllFiles()
 
 createIframe = () ->


### PR DESCRIPTION
This is an initial fix for the errors in IE 6/7 when trying to iterate over localStorage (issue #95). I would prefer to fix this by flushing localStorage using lscache; however, lscache doesn't currently support removing a subset of it's entries. I've got a patch in the works and will try to submit a PR over the weekend (for lscache). If you can wait, I'd suggest holding off until that's done :)
