### PR TITLE
Minor update for backwards compatibility when setting file mode

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -18,7 +18,7 @@ governing permissions and limitations under the License.
 PROJECT = "inject"
 
 path = require("path")
-fs= require("fs")
+fs = require("fs")
 exec = require("child_process").exec
 
 option '', '--config-file [FILE]', 'Load in a json file as config. Defaults to: null.'
@@ -226,9 +226,9 @@ task "build", "Builds inject library", (options)->
       cb()
 
   unclean = (cb = ->) ->
-    fs.mkdir config.tmp, 0o777, (err) ->
+    fs.mkdir config.tmp, parseInt('0777'), (err) ->
       console.error err if err and err.errno isnt 47 and err.errno isnt 17 # 47 is directory already exists. This is ok for the purposes of this function
-      fs.mkdir config.out, 0o777, (err) ->
+      fs.mkdir config.out, parseInt('0777'), (err) ->
         console.error err if err and err.errno isnt 47 and err.errno isnt 17 # directory already exists.
         cb()
 


### PR DESCRIPTION
Add backwards compatibility for coffeescript versions prior to 1.3.1 when determining file mode to pass to fs.mkdir.
