### PR TITLE
Make sure named amd modules are handled correctly.

### DIFF
--- a/examples/deps/named-module-customer.js
+++ b/examples/deps/named-module-customer.js
@@ -1,0 +1,4 @@
+// This module is defined inline in named-amd.html and should *NOT* result in a call to the server to download any file
+var NamedModule = require('named-module');
+
+console.log(NamedModule);

--- a/examples/index.html
+++ b/examples/index.html
@@ -40,6 +40,8 @@
   <dd>how to use the addRule() syntax to support supplemental libraries such as jQuery UI</dd>
   <dt><a href="versioning.html">addRule() for versioning</a>:</dt>
   <dd>how to use the addRule() syntax to support versioning</dd>
+  <dt><a href="named-amd.html">Named AMD Module</a>:</dt>
+  <dd>Use a named AMD module as a way to package server-side generated JS code or as a way to override "require" statements that you don't want to make calls to your server.</dd>
 </dl>
 </body>
 </html>

--- a/examples/named-amd.html
+++ b/examples/named-amd.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <!--
+    Inject
+    Copyright 2011 Jakob Heuser
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an "AS
+    IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied.   See the License for the specific language
+    governing permissions and limitations under the License.
+  -->
+  <!--[if lte IE 7]>
+    <script src="/ie-localstorage-json-shim.js" type="text/javascript" id="ie-localstorage-shim"></script>
+  <![endif]-->
+  <script type="text/javascript" src="/inject.js"></script>
+  <script type="text/javascript">
+    require.setModuleRoot("/examples/deps");
+  </script>
+</head>
+<body>
+<h1>Named AMD</h1>
+<p>Create a named module with AMD and then require it later on. Very useful for defining modules in the HTML from server-side rendered data. Also a handy way to work around require statements in modules that you want to "override".</p>
+
+<p><a href="index.html">Back to examples</a></p>
+
+<button id="clearit">Clear Cache</button>
+
+<script type="text/javascript">
+document.getElementById("clearit").onclick = function() {
+  require.clearCache();
+};
+
+// Define a named module in-line. This is a great way for a server-side rendered template to provide data to your JavaScript code.
+define('named-module', function() {
+  return {
+    foo: "bar"
+  };
+});
+
+// Any JS module that "requires" named-module will now get the data above instead of trying to load named-module.js
+require.run('named-module-customer');
+</script>
+</body>
+</html>

--- a/src/inject.coffee
+++ b/src/inject.coffee
@@ -797,6 +797,9 @@ downloadTree = (tree, callback) ->
     else
       sendToXhr(moduleId, processCallbacks)
 
+  # see if this module has already been loaded and processed
+  if db.module.getExports(moduleId) then return callback()
+
   # queue our results when the file completes
   db.queue.file.add(moduleId, onDownloadComplete)
 
@@ -1276,6 +1279,7 @@ define = (moduleId, deps, callback) ->
     
     # ensureModule should now contain everything we need in order to save this module
     db.module.setExports(moduleId, module.exports)
+    db.module.setExecuted(moduleId, true)
     db.module.setLoading(moduleId, false)
     amdCallbackQueue = db.queue.amd.get(moduleId)
     for amdCallback in amdCallbackQueue


### PR DESCRIPTION
This is a fix for issue #106. It consists of just two changes: (1) after a call to `define`, mark the module as "executed" and (2) shortcut `downloadTree` if we already have `exports` for this module in the `db`.

I've also included a new example to show/test this feature. 

All tests pass.
