### PR TITLE
fixes #77 bug removing explicit jQuery support

### DIFF
--- a/src/inject.coffee
+++ b/src/inject.coffee
@@ -1408,8 +1408,7 @@ define = (moduleId, deps, callback) ->
   loadModules allDeps, afterLoadModules
 
 # To allow a clear indicator that a global define function conforms to the AMD API
-define['amd'] =
-  'jQuery': true # jQuery requires explicitly defining inside of define.amd
+define['amd'] = {}
 
 # set context.require to the main inject object
 # set context.define to the main inject object


### PR DESCRIPTION
This fixes #77, removing explicit support for jQuery's AMD functionality. The recommended use is the pointcuts from our recipe book.
