### PR TITLE
#116 applyRules: a resolved relative path continues through stack 

### DIFF
--- a/src/inject.coffee
+++ b/src/inject.coffee
@@ -82,7 +82,7 @@ defineStaticRequireRegex = /^[\r\n\s]*define\(\s*("\S+",|'\S+',|\s*)\s*\[([^\]]*
 requireGreedyCapture = /require.*/
 commentRegex = /(\/\*([\s\S]*?)\*\/|([^:]|^)\/\/(.*)$)/mg
 relativePathRegex = /^([A-Za-z]|.\/|..\/).*/
-absolutePathRegex = /^(http:\/|https:\/|\/)/
+absolutePathRegex = /^([A-Za-z]+:)?(\/)+/;
 
 ###
 lscache configuration


### PR DESCRIPTION
**I need help testing this before pulling this into the trunk** 

Issue was a combination on line 1147 and 1156 clobbering the code

```

if(typeof userConfig.moduleRoot === "string" ) {
        workingPath = "" + userConfig.moduleRoot + workingPath 

if(typeof relativePath === "string" ) {
    workingPath = basedir(relativePath) + moduleId
  }

```

I updated the relativePathRegex also to account for paths that don't have an initial  '/'
