### PR TITLE
fixes #175 by removing the script tag test for IE browsers

### DIFF
--- a/src/executor.js
+++ b/src/executor.js
@@ -103,15 +103,19 @@ var Executor;
   }
 
   // build a test script and ensure it works
-  context.onerror = function(err, where, line) {
-    onErrorOffset = 3 - line;
-    cleanupEvalScriptNode(testScriptNode);
-    return true;
-  };
-  if (docHead) {
-    docHead.appendChild(testScriptNode);
+  // internet explorer's engine does not need this
+  // functionality. Sorry in advance for the sniff
+  if (!IS_IE) {
+    context.onerror = function(err, where, line) {
+      onErrorOffset = 3 - line;
+      cleanupEvalScriptNode(testScriptNode);
+      return true;
+    };
+    if (docHead) {
+      docHead.appendChild(testScriptNode);
+    }
+    context.onerror = initOldError;
   }
-  context.onerror = initOldError;
   // test script completion
 
   /**


### PR DESCRIPTION
Uses out IS_IE constant to avoid the script test check in internet explorer. The offset check is primarily for firefox (and a trivial op in Chrome). However, in IE, running this can alert people to warnings prematurely.

No sense in raising alarms.
