### PR TITLE
Resolves gh-244 option to disable global define.amd

### DIFF
--- a/src/includes/context.js
+++ b/src/includes/context.js
@@ -186,6 +186,20 @@ context.Inject = {
   },
 
   /**
+   * Set the global AMD property. Setting this to "true" can disable
+   * the global AMD detection. This is really useful in scenarios where
+   * you anticipate mixing script tags with your loader framework
+   */
+  disableGlobalAMD: function (disable) {
+    if (disable) {
+      context.define = Inject.INTERNAL.createDefine(null, null, true);
+    }
+    else {
+      context.define = Inject.INTERNAL.createDefine();
+    }
+  },
+
+  /**
       Clears the local storage caches.
       @see InjectCore.clearCache
       @method

--- a/src/injectcore.js
+++ b/src/injectcore.js
@@ -65,13 +65,14 @@ var InjectCore;
        * @method InjectCore.createDefine
        * @param {string} id - the module identifier for relative module IDs
        * @param {string} path - the module path for relative path operations
+       * @param {boolean} disableAMD - if provided, define.amd will be false, disabling AMD detection
        * @public
        * @returns a function adhearing to the AMD define() method
        */
-      createDefine: function (id, path) {
+      createDefine: function (id, path, disableAMD) {
         var req = new RequireContext(id, path);
         var define = proxy(req.define, req);
-        define.amd = {};
+        define.amd = (disableAMD) ? false : {};
         return define;
       },
 

--- a/tests/integration/tests/anon_define_240.js
+++ b/tests/integration/tests/anon_define_240.js
@@ -11,3 +11,10 @@ test("#240 fail gracefully when an anonymous define is used out of context - AMD
   }
   ok(pass, "Properly throws an AMD related error as opposed to an untracable issue.");
 });
+
+// #244, disable amd detection
+test("#244 disable the global AMD, preventing errors", function() {
+  var pass = false;
+  Inject.disableGlobalAMD(true);
+  ok(false === define.amd, "Global AMD detection can be disabled via a config");
+});


### PR DESCRIPTION
Config option and tests added to disable the global define.amd
This change and tests enables a user to mix script tags with their
loader, with an interface to enable/disable the primary form of
detection: define.amd.

This addresses use cases where a user has loaded Inject, and then
places a script tag on the page that tests for define&&define.amd,
attempting to register an anonymous module.

gh-244
