### PR TITLE
Fix css plugin for IE7

### DIFF
--- a/src/plugins/css.js
+++ b/src/plugins/css.js
@@ -23,9 +23,9 @@ governing permissions and limitations under the License.
 **/
 (function () {
   var style = document.createElement('style');
+  style.type = 'text/css';
   var placed = false;
   var useCssText = (style.styleSheet) ? true : false;
-  style.type = 'text/css';
 
   function CSS(txt) {
     this.txt = txt;
@@ -58,7 +58,7 @@ governing permissions and limitations under the License.
     },
     addStyles: function (text) {
       if (useCssText) {
-        style.styleSheet.cssText = [style.styleSheet.cssText, text].join('\n');
+        style.styleSheet.cssText = [style.innerHTML, text].join('\n');
       }
       else {
         style.appendChild(document.createTextNode(text));


### PR DESCRIPTION
`var style = document.createElement('style');`
`var useCssText = (style.styleSheet) ? true : false;`
`style.type = 'text/css';`

results in useCssText = false in IE7 which is causing wrong logic to execute for attaching css styles.

`var style = document.createElement('style');`
`style.type = 'text/css';`
`var useCssText = (style.styleSheet) ? true : false;`

results in useCssText = true, hence moving up style.type assignment.

IE7 also throws 'Access denied' exception on 

`style.styleSheet.cssText = [style.styleSheet.cssText, text].join('\n');`

It can not read value of the `style.styleSheet.cssText`, so replacing it with `style.innerHTML`.

I've checked value of `style.innerHTML` before and after adding styles using `style.styleSheet.cssText`. InnerHTML correctly reflects changes made via cssText so I think it should be a safe change.
