### PR TITLE
Performance changes to minimize LinkJS Impact

### DIFF
--- a/src/analyzer.js
+++ b/src/analyzer.js
@@ -78,7 +78,7 @@ var Analyzer;
           '(?:^|[\\s;,=\\?:\\}\\)\\(])' + // begins with start of string, and any symbol a function call() can follow
           'require[\\s]*\\('+             // the keyword "require", whitespace, and then an opening paren
           '[\'"]'+                        // a quoted stirng (require takes a single or double quoted string)
-          '(.+?)'+                        // the valid characters for a "module identifier"... includes AMD characters
+          '([^\'"]+?)'+                   // the valid characters for a "module identifier"... includes AMD characters. You cannot match a quote
           '[\'"]' +                       // the closing quote character
           '\\)',                          // end of paren for "require"
           'gi'                            // flags: global, case-insensitive

--- a/tests/src/analyzer.html
+++ b/tests/src/analyzer.html
@@ -71,7 +71,7 @@ governing permissions and limitations under the License.
       var totalOk = requireSampleCode.match(okRegex).length;
 
       ok(result.length > 0, "found some require statements");
-      equal(result.length, totalOk, "all expected require() statements found: "+result.join(" "));
+      equal(result.length, totalOk, "all expected require() statements found: "+result.join("&&"));
 
       // loop through everything in results, ensure we don't match a bad one
       for (var i = 0, len = result.length; i < len; i++) {


### PR DESCRIPTION
The LinkJS Library has lessened our maintenance burden in two key areas:
- Detecting parse errors during execution (in executor.js)
- Extracting dependencies (in analyzer.js)

@gvsboy posted to the internal mailing list that performance in 0.5.0 was down. This was especially noticeable with larger files. The culprit was determined to be the LinkJS source. The tokenizing / parsing is just too heavyweight for Inject.

This pull request pulls in a cleaner (documented) version of the regex items used back in 0.4.2, and cleans up the execution to be more readable. Additionally, LinkJS is only invoked during execution once the eval() enters the failed state via a try/catch block. The additional try/catch weight should be minimal, as it's invoked only during the error cases.
