### PR TITLE
fix(Communicator, Relay) repairs broken event listener calls

### DIFF
--- a/src/communicator.js
+++ b/src/communicator.js
@@ -117,7 +117,7 @@ var Communicator = Fiber.extend(function() {
       }
       this.alreadyListening = true;
     
-      this.listenFor(window, 'message', function(e) {
+      addListener(window, 'message', function(e) {
         var commands, command, params;
     
         if (!self.env.config.relayFile) {

--- a/src/xd/postmessage.js
+++ b/src/xd/postmessage.js
@@ -17,6 +17,15 @@ governing permissions and limitations under the License.
 
 var reURI = /^((http.?:)\/\/([^:\/\s]+)(:\d+)*)/; // returns groups for protocol (2), domain (3) and port (4) 
 
+function addListener(el, evt, fn) {
+  if (window.addEventListener) {
+    el.addEventListener(evt, fn, false);
+  }
+  else {
+    el.attachEvent('on' + evt, fn);
+  }
+}
+
 function getDomainName(url) {
   return url.match(reURI)[3];
 }


### PR DESCRIPTION
Two errors have emerged as a result of some refactoring I did in pull request #290 (https://github.com/linkedin/inject/pull/290) involving moving the event attachment method to global scope:
1. Communicator was neglected.
2. relay.html, which is dynamically generated, was missing the event attachment method as it was moved from postmessage.js to globals.js.

I've resolved the issues by updating the called method in Communicator and adding the method back to postmessage.js.
