### PR TITLE
fix #313 where sandboxed iframes causes Inject getDomainName to fail

### DIFF
--- a/src/communicator.js
+++ b/src/communicator.js
@@ -124,7 +124,7 @@ var Communicator = Fiber.extend(function() {
           return;
         }
 
-        if (getDomainName(e.origin) !== getDomainName(self.env.config.relayFile)) {
+        if (e.origin === 'null' || getDomainName(e.origin) !== getDomainName(self.env.config.relayFile)) {
           return;
         }
 

--- a/src/xd/postmessage.js
+++ b/src/xd/postmessage.js
@@ -27,7 +27,8 @@ function addListener(el, evt, fn) {
 }
 
 function getDomainName(url) {
-  return url.match(reURI)[3];
+  var matched = url.match(reURI);
+  return matched ? url.match(reURI)[3]: null;
 }
 
 function sendMessage(target, targetsUrl, command, params) {

--- a/src/xd/relay.js
+++ b/src/xd/relay.js
@@ -35,7 +35,7 @@ window.setTimeout(function() {
 addListener(window, 'message', function(e) {
   var commands, command, params, xhr, cachedFile;
   
-  if (getDomainName(e.origin) !== getDomainName(returnUrl)) {
+  if (e.origin === 'null' || getDomainName(e.origin) !== getDomainName(returnUrl)) {
     return;
   }
   


### PR DESCRIPTION
- check against the `'null'` messageEvent origin
- check against bad regex matches of the domainName
